### PR TITLE
HSC-281: Fix translations and retire forms

### DIFF
--- a/configs/openmrs/frontend_config/ozone-frontend-config.json
+++ b/configs/openmrs/frontend_config/ozone-frontend-config.json
@@ -41,6 +41,7 @@
     "fieldDefinitions": [
       {
         "id": "email",
+        "label": "Email Address",
         "type": "person attribute",
         "uuid": "d9b2d63d-6b6d-4c9e-b4e1-6e8f4f3efc3e",
         "placeholder": "placeholder"
@@ -192,25 +193,28 @@
         "selectAnOption": "Select an option",
         "createNew": "Register",
         "patient": "New Patient",
-        "familyName": "Last Name"
+        "familyNameLabelText": "Last Name",
+        "emailLabelText": "Email Address",
+        "genderLabelText": "Gender"
       },
       "fr": {
         "Commune": "Commune",
         "Village": "Pays",
-        "Country": "",
+        "Country": "Country",
         "Province": "Département",
-        "District": "",
-        "contactSection": "",
-        "demographicsSection": "",
-        "additionalInformationSection": "",
-        "Male": "",
-        "Female": "",
-        "Other": "",
-        "Unknown": "",
-        "selectAnOption": "",
-        "createNew": "",
-        "patient": "",
-        "familyName": "Last Name"
+        "District": "District",
+        "contactSection": "Contact Details",
+        "demographicsSection": "Basic Info",
+        "additionalInformationSection": "Additional Information",
+        "Male": "Homme",
+        "Female": "Femme",
+        "Other": "Autre",
+        "selectAnOption": "Select an option",
+        "createNew": "Register",
+        "patient": "New Patient",
+        "familyNameLabelText": "Nom de famille",
+        "emailLabelText": "Email Address",
+        "genderLabelText": "Gender"
       }
     }
   },

--- a/configs/openmrs/initializer_config/ampathforms/mode_of_arrival_1.json
+++ b/configs/openmrs/initializer_config/ampathforms/mode_of_arrival_1.json
@@ -1,66 +1,67 @@
 {
-    "name": "Moyen de transport",
-    "pages": [
-      {
-        "label": "Moyen de transport",
-        "sections": [
-          {
-            "label": "Moyen de transport",
-            "isExpanded": "true",
-            "questions": [
-              {
-                "label": "Moyen de transport",
-                "type": "obs",
-                "required": false,
-                "id": "moyenDeTransport",
-                "questionOptions": {
-                  "rendering": "radio",
-                  "concept": "f83eeb93-703a-4dd5-bd95-51a6580b4065",
-                  "answers": [
-                    {
-                      "concept": "8e84e437-35fa-4d31-8be9-9aa999f1ff94",
-                      "label": "Ambulated"
-                    },
-                    {
-                      "concept": "0b290aeb-b4f6-4b37-b114-e7ce2e4c304c",
-                      "label": "Car"
-                    },
-                    {
-                      "concept": "7a5b55b6-4617-42b9-808c-82116a259a6e",
-                      "label": "Minibus"
-                    },
-                    {
-                      "concept": "26c0366b-83e4-4401-9699-e545219b8870",
-                      "label": "Other"
-                    }
-                  ]
-                },
-                "validators": []
+  "name": "Moyen de transport",
+  "pages": [
+    {
+      "label": "Moyen de transport",
+      "sections": [
+        {
+          "label": "Moyen de transport",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Moyen de transport",
+              "type": "obs",
+              "required": false,
+              "id": "moyenDeTransport",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "f83eeb93-703a-4dd5-bd95-51a6580b4065",
+                "answers": [
+                  {
+                    "concept": "8e84e437-35fa-4d31-8be9-9aa999f1ff94",
+                    "label": "Ambulated"
+                  },
+                  {
+                    "concept": "0b290aeb-b4f6-4b37-b114-e7ce2e4c304c",
+                    "label": "Car"
+                  },
+                  {
+                    "concept": "7a5b55b6-4617-42b9-808c-82116a259a6e",
+                    "label": "Minibus"
+                  },
+                  {
+                    "concept": "26c0366b-83e4-4401-9699-e545219b8870",
+                    "label": "Other"
+                  }
+                ]
               },
-              {"hide": {
-                  "hideWhenExpression": "isEmpty(moyenDeTransport) ||  moyenDeTransport !== '26c0366b-83e4-4401-9699-e545219b8870'"
-                },
-                "label": "Other observations",
-                "type": "obs",
-                "required": false,
-                "id": "otherObservations",
-                "questionOptions": {
-                  "rendering": "textarea",
-                  "concept": "4d1f668f-f9b7-4e95-8436-53f37e8c643e"
-                },
-                "validators": []
-              }
-            ]
-          }
-        ]
-      }
-    ],
-    "processor": "EncounterFormProcessor",
-    "encounter": "Consultation",
-    "referencedForms": [],
-    "uuid": "e2d88e5b-6391-4dda-ac2f-4b48b2d1e86b",
-    "description": "Moyen de transport",
-    "version": "1",
-    "published": true,
-    "retired": false
-  }
+              "validators": []
+            },
+            {
+              "hide": {
+                "hideWhenExpression": "isEmpty(moyenDeTransport) ||  moyenDeTransport !== '26c0366b-83e4-4401-9699-e545219b8870'"
+              },
+              "label": "Other observations",
+              "type": "obs",
+              "required": false,
+              "id": "otherObservations",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "4d1f668f-f9b7-4e95-8436-53f37e8c643e"
+              },
+              "validators": []
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "processor": "EncounterFormProcessor",
+  "encounter": "Consultation",
+  "referencedForms": [],
+  "uuid": "e2d88e5b-6391-4dda-ac2f-4b48b2d1e86b",
+  "description": "Moyen de transport",
+  "version": "1",
+  "published": true,
+  "retired": true
+}

--- a/configs/openmrs/initializer_config/ampathforms/triage.json
+++ b/configs/openmrs/initializer_config/ampathforms/triage.json
@@ -1,56 +1,56 @@
 {
-    "name": "Triage",
-    "pages": [
-      {
-        "label": "Triage",
-        "sections": [
-          {
-            "label": "Triage",
-            "isExpanded": "true",
-            "questions": [
-              {
-                "label": "Level of emergency severity assessment",
-                "type": "obs",
-                "required": true,
-                "id": "levelOfEmergencySeverityAssessment",
-                "questionOptions": {
-                  "rendering": "radio",
-                  "concept": "bbb02557-0277-4979-a1fa-b0020f136066",
-                  "conceptMappings": [
-                    {
-                      "relationship": "SAME-AS",
-                      "type": "CIEL",
-                      "value": "159637"
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "concept": "04f6f7e0-e3cb-4e13-a133-4479f759574e",
-                      "label": "Emergency"
-                    },
-                    {
-                      "concept": "78063dec-b6d8-40c1-9483-dd4d3c3ca434",
-                      "label": "Priority"
-                    },
-                    {
-                      "concept": "617fbfdc-31b5-414c-8964-8cb148cab662",
-                      "label": "Queue"
-                    }
-                  ]
-                },
-                "validators": []
-              }
-            ]
-          }
-        ]
-      }
-    ],
-    "processor": "EncounterFormProcessor",
-    "encounter": "Consultation",
-    "referencedForms": [],
-    "uuid": "4a9b9960-389a-4498-bda4-f0c03c7be877",
-    "description": "Triage Form",
-    "version": "1",
-    "published": true,
-    "retired": false
-  }
+  "name": "Triage",
+  "pages": [
+    {
+      "label": "Triage",
+      "sections": [
+        {
+          "label": "Triage",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Level of emergency severity assessment",
+              "type": "obs",
+              "required": true,
+              "id": "levelOfEmergencySeverityAssessment",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "bbb02557-0277-4979-a1fa-b0020f136066",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "159637"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "04f6f7e0-e3cb-4e13-a133-4479f759574e",
+                    "label": "Emergency"
+                  },
+                  {
+                    "concept": "78063dec-b6d8-40c1-9483-dd4d3c3ca434",
+                    "label": "Priority"
+                  },
+                  {
+                    "concept": "617fbfdc-31b5-414c-8964-8cb148cab662",
+                    "label": "Queue"
+                  }
+                ]
+              },
+              "validators": []
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "processor": "EncounterFormProcessor",
+  "encounter": "Consultation",
+  "referencedForms": [],
+  "uuid": "4a9b9960-389a-4498-bda4-f0c03c7be877",
+  "description": "Triage Form",
+  "version": "1",
+  "published": true,
+  "retired": true
+}


### PR DESCRIPTION
Ticket :https://mekomsolutions.atlassian.net/browse/HSC-281

Last Name translation Added.

![image](https://github.com/user-attachments/assets/16abc1fd-387d-4988-9cf9-e0d825420950)

Email label set to Email Address

![image](https://github.com/user-attachments/assets/217d3e10-23c1-4beb-b094-fc198d1ac502)

Two redundant forms were replace by two visit attributes thus they have been retired.


