### PR TITLE
OZ-678: Update `ozone/` to `configs/` for serving frontend configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,8 @@ settings.xml
 # Gradle
 .idea/**/gradle.xml
 .idea/**/libraries
+.idea/material_theme_project_new.xml
+.idea/.gitignore
 
 # Gradle and Maven with auto-import
 # When using Gradle or Maven with auto-import, you should exclude module files,

--- a/configs/openmrs/frontend_config/ozone-frontend-config.json
+++ b/configs/openmrs/frontend_config/ozone-frontend-config.json
@@ -234,19 +234,19 @@
       }
     ],
     "logo": {
-      "src": "ozone/ozone_hsc_logo_white.png",
+      "src": "configs/ozone_hsc_logo_white.png",
       "alt": "hsc-logo"
     }
   },
   "@openmrs/esm-login-app": {
     "logo": {
-      "src": "ozone/ozone_hsc_logo.png",
+      "src": "configs/ozone_hsc_logo.png",
       "alt": "hsc-logo"
     }
   },
   "@openmrs/esm-patient-chart-app": {
     "logo": {
-      "src": "ozone/ozone_hsc_logo_white.png",
+      "src": "configs/ozone_hsc_logo_white.png",
       "alt": "hsc-logo"
     },
     "Display conditions": {
@@ -293,7 +293,7 @@
       "header": {
         "showBarcode": true,
         "showLogo": true,
-        "logo": "ozone/ozone_hsc_logo.png"
+        "logo": "configs/ozone_hsc_logo.png"
       }
     }
   }


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/jira/software/c/projects/OZ/issues/OZ-698

This PR updates `ozone/` to `configs/` because frontend assets/configs is now served at `/configs`