### PR TITLE
HSC-281: Fixed concept UUID for Cause of death

### DIFF
--- a/configs/openmrs/frontend_config/ozone-frontend-config.json
+++ b/configs/openmrs/frontend_config/ozone-frontend-config.json
@@ -8,6 +8,9 @@
       "relationships"
     ],
     "fieldConfigurations": {
+      "causeOfDeath": {
+        "conceptUuid": "30e1c728-f008-4dd1-ab34-2c34a00fd3a5"
+      },
       "address": {
         "useAddressHierarchy": {
           "enabled": true,


### PR DESCRIPTION
After excluding the cause of death at the Haiti level [here](https://github.com/mekomsolutions/ozone-haiti/blob/705b33961f90788d7dcb428f0f65b619c82f4465/pom.xml#L91) it became necesssary to explicitly add the UUID in the patient-registration-app