### PR TITLE
HSC-302: Set the O3 drug order type to use existing drug order type

### DIFF
--- a/configs/openmrs/frontend_config/ozone-frontend-config.json
+++ b/configs/openmrs/frontend_config/ozone-frontend-config.json
@@ -403,7 +403,8 @@
     "daysDurationUnit": {
       "uuid": "327cdb97-571c-2d13-306b-4024fce268cb",
       "display": "Day(s)"
-    }
+    },
+    "drugOrderTypeUUID": "16bb6bcf-2e81-4ba5-8583-ff4913201a72"
   },
   "@openmrs/esm-patient-tests-app": {
     "resultsViewerConcepts": [


### PR DESCRIPTION
https://mekomsolutions.atlassian.net/browse/HSC-302

Setting the Drug Order type UUID as per what is in the current production database.