### PR TITLE
Override OpenMRS frontend build Groovy script to pin `react-aria-components`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,28 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <!-- Override OpenMRS frontend build Groovy script -->
+                    <execution>
+                        <id>Override OpenMRS frontend build Groovy script</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/scripts</directory>
+                                    <includes>
+                                        <include>
+                                            openmrs/frontend_assembly/build-openmrs-frontend.groovy
+                                        </include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                     <execution>
                         <!-- Copy Monitoring Binary Resources -->
                         <id>Copy Monitoring Resources </id>

--- a/scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy
+++ b/scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy
@@ -1,0 +1,94 @@
+import java.nio.file.Paths
+
+log.info("Checking for frontend customizations in ${Paths.get("${project.build.directory}", "openmrs_frontend", "spa-assemble-config.json").toString()}")
+
+def refAppConfigFile = Paths.get("${project.build.directory}", "openmrs_frontend", "reference-application-spa-assemble-config.json").toFile()
+def slurper = new groovy.json.JsonSlurper()
+def refAppConfig = slurper.parse(refAppConfigFile)
+def openmrsVersion = refAppConfig["coreVersion"] ?: "next"
+def outputDirectory = "${project.groupId}" == "com.ozonehis" && "${project.artifactId}" == "ozone-distro" ?
+    "${project.build.directory}/${project.artifactId}-${project.version}/binaries/openmrs/frontend" :
+    "${project.build.directory}/${project.artifactId}-${project.version}/distro/binaries/openmrs/frontend"
+
+def outputDirectoryFile = new File(outputDirectory)
+
+def assembleCommand = "npx --legacy-peer-deps openmrs@${openmrsVersion} assemble --manifest --mode config --target ${outputDirectory} --config ${refAppConfigFile.getAbsolutePath()}"
+log.info("Project: ${project.groupId}:${project.artifactId}")
+// by default, we build the frontend as part of Ozone and only rebuild if there are local customizations
+def shouldBuildFrontend = "${project.groupId}" == "com.ozonehis" && "${project.artifactId}" == "ozone-distro"
+
+if (!shouldBuildFrontend) {
+    frontendCustomizationsFile = Paths.get("${project.build.directory}", "openmrs_frontend", "spa-assemble-config.json").toFile()
+    if (frontendCustomizationsFile.exists()) {
+        log.info("Found frontend customizations. Rebuilding frontend...")
+
+        assembleCommand += " --config ${frontendCustomizationsFile.getAbsolutePath()}"
+        shouldBuildFrontend = true
+        // Update the OpenMRS version to the one specified in the customizations file if it exists.
+        def newOpenmrsCoreVersion = slurper.parse(frontendCustomizationsFile)["coreVersion"] ?: openmrsVersion
+        // Update the OpenMRS version in the assemble command if it is different from the current version.
+        if (newOpenmrsCoreVersion != openmrsVersion) {
+            assembleCommand = assembleCommand.replace(openmrsVersion, newOpenmrsCoreVersion)
+            openmrsVersion = newOpenmrsCoreVersion
+        }
+        log.info("Using OpenMRS Frontend Core Version: ${openmrsVersion}")
+    }
+}
+
+if (shouldBuildFrontend) {
+    log.info("Cleaning ${outputDirectory}...")
+    if (outputDirectoryFile.exists()) {
+        outputDirectoryFile.eachFile({ it -> it.delete() })
+        outputDirectoryFile.eachDir({ it -> if (it.getName() != "ozone") { it.deleteDir() } })
+    }
+
+    log.info("Running assemble command...")
+    log.info(assembleCommand)
+
+    def assembleProcess = assembleCommand.execute()
+    assembleProcess.consumeProcessOutput(System.out, System.err)
+    assembleProcess.waitFor()
+
+    if (assembleProcess.exitValue() != 0) {
+        throw new RuntimeException("'openmrs assemble' step failed. See previous messages for details.")
+    }
+
+    log.info("Running build command...")
+    def packageJsonFile = new File(outputDirectory, "package.json")
+    log.info("Writing package.json with openmrs dependency and overrides to ${packageJsonFile.getAbsolutePath()}...")
+    packageJsonFile.text = """\
+    {
+      "name": "openmrs-frontend-build",
+      "version": "1.0.0",
+      "dependencies": {
+        "openmrs": "${openmrsVersion}"
+      },
+      "overrides": {
+        "react-aria-components": "1.8.0"
+      }
+    }
+    """
+
+    // Install openmrs and all dependencies locally so webpack can resolve overridden packages correctly.
+    log.info("Installing openmrs@${openmrsVersion} and dependencies with overrides in ${outputDirectory}...")
+    def installProcess = "npm install --legacy-peer-deps".execute(null, new File(outputDirectory))
+    installProcess.consumeProcessOutput(System.out, System.err)
+    installProcess.waitFor()
+
+    if (installProcess.exitValue() != 0) {
+        throw new RuntimeException("Failed to install openmrs and dependencies. See previous messages for details.")
+    }
+
+    log.info("Using OpenMRS Frontend Core Version for build: ${openmrsVersion}")
+
+    // Run the build using the locally installed openmrs binary so it picks up the local node_modules with overrides.
+    def buildProcess = "${outputDirectory}/node_modules/.bin/openmrs build --config-url \$SPA_CONFIG_URLS --default-locale \$SPA_DEFAULT_LOCALE --target ${outputDirectory}".execute()
+    buildProcess.consumeProcessOutput(System.out, System.err)
+    buildProcess.waitFor()
+
+    if (buildProcess.exitValue() != 0) {
+        throw new RuntimeException("'openmrs build' step failed. See previous messages for details.")
+    }
+} else {
+    log.info("No need to re-build the frontend detected")
+}


### PR DESCRIPTION
This PR overrides OpenMRS frontend build Groovy script to allow installing of `openmrs` tooling thus applying `react-aria-components` override